### PR TITLE
Fix for BuildExtendedChar not found error

### DIFF
--- a/datasource_classes/RetrieveFMXML.class.php
+++ b/datasource_classes/RetrieveFMXML.class.php
@@ -51,12 +51,12 @@ class RetrieveFMXML extends RetrieveFXData {
     );
 
     var $UTF8HTMLEntities = array(
-        "\$this->BuildExtendedChar('\\1','\\2')",
-        "\$this->BuildExtendedChar('\\1','\\2','\\3')",
-        "\$this->BuildExtendedChar('\\1','\\2','\\3')",
-        "\$this->BuildExtendedChar('\\1','\\2','\\3','\\4')",
-        "\$this->BuildExtendedChar('\\1','\\2','\\3','\\4')",
-        "\$this->BuildExtendedChar('\\1','\\2','\\3','\\4')"
+        "\$this->FX->BuildExtendedChar('\\1','\\2')",
+        "\$this->FX->BuildExtendedChar('\\1','\\2','\\3')",
+        "\$this->FX->BuildExtendedChar('\\1','\\2','\\3')",
+        "\$this->FX->BuildExtendedChar('\\1','\\2','\\3','\\4')",
+        "\$this->FX->BuildExtendedChar('\\1','\\2','\\3','\\4')",
+        "\$this->FX->BuildExtendedChar('\\1','\\2','\\3','\\4')"
     );
 
     function getTOCName($fieldName) {


### PR DESCRIPTION
On my site, half of my forms worked and half of them did not, without this fix.
