### PR TITLE
fmalt uses fmresultset.xml to parse the filemaker xml data from FileMake...

### DIFF
--- a/FX.php
+++ b/FX.php
@@ -131,6 +131,8 @@ class FX {
     var $remainNamesReverse = array();    // Added by Masayuki Nii(nii@msyk.net) Jan 23, 2010
     var $portalAsRecord =false;    // Added by Masayuki Nii(nii@msyk.net) Dec 18, 2010
 
+    var $usePortalIDs = false;    // for use with the RetrieveFM7VerboseData.class "fmalt"
+
     // Flags and Error Tracking
     var $fieldCount = 0;
     var $fxError = 'No Action Taken';
@@ -177,9 +179,9 @@ class FX {
         if ($this->dataServerType == 'fmpro') {
             $this->dataServerVersion = intval(str_replace('fmpro', '', strtolower($dataType)));
         } else {
-            $this->dataServerVersion = 0;
+                $this->dataServerVersion = 0;
         }
-        if (strlen($dataURLType) > 0 && $this->dataServerVersion >= 7 && $this->dataServerType == 'fmpro' && strtolower($dataURLType) == 'https') {
+        if (((strlen($dataURLType) > 0 && $this->dataServerVersion >= 7 && $this->dataServerType == 'fmpro') || ($this->dataServerType == 'fmalt')) && strtolower($dataURLType) == 'https') {
             $this->useSSLProtocol = true;
             $this->urlScheme = 'https';
         } else {
@@ -253,6 +255,19 @@ class FX {
                     require_once('datasource_classes/RetrieveFM5Data.class.php');
                     $datasourceClassName = 'RetrieveFM5Data';
                     $datasourceDescription = 'FileMaker Pro 5/6';
+                }
+                break;
+            case 'fmalt':
+                // calls to FMView require this fix as of server version 12 to 12.0v2, so far
+                if ($action == '-view')
+                {
+                    require_once('datasource_classes/RetrieveFM7Data.class.php');
+                    $datasourceClassName = 'RetrieveFM7Data';
+                    $datasourceDescription = 'FileMaker Server 7+';
+                } else {
+                    require_once('datasource_classes/RetrieveFM7VerboseData.class.php');
+                    $datasourceClassName = 'RetrieveFM7VerboseData';
+                    $datasourceDescription = 'FileMaker Server 7+ Verbose';
                 }
                 break;
             case 'openb':

--- a/datasource_classes/RetrieveFM7Data.class.php
+++ b/datasource_classes/RetrieveFM7Data.class.php
@@ -11,6 +11,10 @@ require_once('RetrieveFMXML.class.php');
 
 class RetrieveFM7Data extends RetrieveFMXML {
 
+    var $fmDataFile = 'FMPXMLRESULT.xml';
+    var $xmlStartHandler = 'StartElement';
+    var $xmlContentHandler = 'ElementContents';
+    var $xmlEndHandler = 'EndElement';
 
     function CreateCurrentSort () {
         $currentSort = "";
@@ -115,7 +119,7 @@ class RetrieveFM7Data extends RetrieveFMXML {
         if ($action == '-view') {
             $FMFile = 'FMPXMLLAYOUT.xml';
         } else {
-            $FMFile = 'FMPXMLRESULT.xml';
+            $FMFile = $this->fmDataFile;
         }
         $this->dataURL = "{$this->FX->urlScheme}://{$this->FX->userPass}{$this->FX->dataServer}{$this->FX->dataPortSuffix}/fmi/xml/{$FMFile}"; // First add the server info to the URL...
         $this->dataURLParams = $this->AssembleCurrentQuery($layRequest, $skipRequest, $currentSort, $currentSearch, $action, 7);
@@ -241,8 +245,8 @@ This function is particularly written for huge queries of data that are less lik
         // Parse the XML
         $xml_parser = xml_parser_create("UTF-8");
         xml_set_object($xml_parser, $this);
-        xml_set_element_handler($xml_parser, "StartElement", "EndElement");
-        xml_set_character_data_handler($xml_parser, "ElementContents");
+        xml_set_element_handler($xml_parser, $this->xmlStartHandler, $this->xmlEndHandler);
+        xml_set_character_data_handler($xml_parser, $this->xmlContentHandler);
         $xmlParseResult = xml_parse($xml_parser, $data, true);
         if (! $xmlParseResult) {
 /* Masayuki Nii added at Oct 9, 2009 */

--- a/datasource_classes/RetrieveFM7VerboseData.class.php
+++ b/datasource_classes/RetrieveFM7VerboseData.class.php
@@ -1,0 +1,205 @@
+<?php
+
+require_once('RetrieveFM7Data.class.php');
+
+#### Part of FX.php #####################################################
+#                                                                       #
+#  License: Artistic License and addendum (included with release)       #
+# Web Site: www.iviking.org                                             #
+#                                                                       #
+#########################################################################
+
+class RetrieveFM7VerboseData extends RetrieveFM7Data {
+
+    var $currentFlag = '';
+    var $currentRecord = '';
+    var $currentSubrecordIndex;
+    var $currentField = '';
+    var $currentFieldIndex;
+    var $isInRelatedSet = false;
+    var $relatedSetTOC = '';
+
+    // these values overwrite those in the parent class
+    var $fmDataFile = 'fmresultset.xml';
+    var $xmlStartHandler = 'elementStartVerbose';
+    var $xmlContentHandler = 'elementContentsVerbose';
+    var $xmlEndHandler = 'elementEndVerbose';
+
+    /*
+     * The functions for new XML parsing begin here
+     */
+    function elementStartVerbose ($parser, $name, $attrs) {
+        switch(strtolower($name)) {
+            case 'data':
+                $this->currentFlag = "parseData";
+                if ($this->FX->useInnerArray) {
+                    $this->FX->currentData[$this->currentRecord][$this->currentField][$this->currentFieldIndex] = "";
+                } else {
+                    if ($this->isRemainName($this->currentField))    {
+                        if ($this->FX->portalAsRecord ) {
+                            $this->FX->currentData[$this->currentRecord][$this->getTOCName($this->currentField)][$this->currentSubrecordIndex][$this->currentField] = '';
+                        } else {
+                            $this->FX->currentData[$this->currentRecord][$this->currentField][$this->currentFieldIndex] = "";
+                        }
+                    } else {
+                        $this->FX->currentData[$this->currentRecord][$this->currentField] = "";
+                    }
+                }
+                break;
+            case 'field':
+                if ($this->isInRelatedSet) {
+                    $this->currentFieldIndex = $this->currentSubrecordIndex;
+                }
+                else $this->currentFieldIndex = 0;
+                $this->currentField = $attrs['NAME'];
+                if ($this->FX->useInnerArray && !$this->isInRelatedSet) {
+                    $this->FX->currentData[$this->currentRecord][$this->currentField] = array();
+                } else if ($this->isRemainName($this->currentField) && !$this->FX->portalAsRecord) {
+                    $this->FX->currentData[$this->currentRecord][$this->currentField] = array();
+                }
+                break;
+            case 'record':
+                $recordID = $attrs['RECORD-ID'];
+                if (substr_count($this->dataURL, '-dbnames') > 0) {
+                    $modID = count($this->FX->currentData);
+                }
+                else {
+                    $modID = $attrs['MOD-ID'];
+                }
+                if ($this->isInRelatedSet) {
+                    if ($this->FX->usePortalIDs) $this->currentSubrecordIndex = $recordID . '.' . $modID;
+                    if ($this->FX->portalAsRecord) {
+                        $this->FX->currentData[$this->currentRecord] = array( '-recid' => $recordID, '-modid' => $modID );
+                    }
+                }
+                else {
+                    $this->currentRecord = $recordID . '.' . $modID;
+                    $this->FX->currentData[$this->currentRecord] = array();
+                }
+                break;
+            case 'relatedset':
+                if ($attrs['COUNT'] > 0) {
+                    $this->isInRelatedSet = true;
+                    $this->currentSubrecordIndex = 0;
+                    $this->relatedSetTOC = $attrs['TABLE'];
+                }
+                break;
+            case 'datasource':
+                // TODO: Do we want to allow use of the additional data provided here now?
+                $this->FX->dateFormat = $attrs['DATE-FORMAT'];
+                $this->FX->timeFormat = $attrs['TIME-FORMAT'];
+                $this->FX->totalRecordCount = $attrs['TOTAL-COUNT'];
+                break;
+            case 'field-definition':
+                if ($this->FX->charSet  != '' && defined('MB_OVERLOAD_STRING')) {
+                    $this->FX->fieldInfo[$this->FX->fieldCount]['name'] = mb_convert_encoding($attrs['NAME'], $this->FX->charSet, 'UTF-8');
+                }
+                else {
+                    $this->FX->fieldInfo[$this->FX->fieldCount]['name'] = $attrs['NAME'];
+                }
+                $this->FX->fieldInfo[$this->FX->fieldCount]['emptyok'] = (($attrs['NOT-EMPTY'] == 'yes')?'no':'yes');
+                $this->FX->fieldInfo[$this->FX->fieldCount]['maxrepeat'] = $attrs['MAX-REPEAT'];
+                $this->FX->fieldInfo[$this->FX->fieldCount]['type'] = $attrs['RESULT'];
+                $this->FX->fieldInfo[$this->FX->fieldCount]['extra'] = ''; // for compatibility w/ SQL databases
+                if (substr_count($this->dataURL, '-view') < 1) {
+                    $this->FX->fieldCount++;
+                }
+                break;
+            case 'resultset':
+                $this->FX->foundCount = (int)$attrs['COUNT'];
+                break;
+            case 'error':
+                $this->FX->fxError = $attrs['CODE'];
+                break;
+            case 'product':
+                break;
+            default:
+                break;
+        }
+    }
+
+    function elementContentsVerbose($parser, $data) {
+        switch($this->currentFlag) {
+            case 'parseData':
+                if ($this->FX->useInnerArray) {
+                    $this->FX->currentData[$this->currentRecord][$this->currentField][$this->currentFieldIndex] .= $this->xmlDecode($data);
+                } else {
+                    if ($this->isRemainName($this->currentField))    {
+                        if ( $this->FX->portalAsRecord ) {
+                            $this->FX->currentData[$this->currentRecord][$this->relatedSetTOC][$this->currentSubrecordIndex][$this->currentField] .= $this->xmlDecode($data);
+                        } else {
+                            $this->FX->currentData[$this->currentRecord][$this->currentField][$this->currentFieldIndex] .= $this->xmlDecode($data);
+                        }
+                    } else {
+                        $this->FX->currentData[$this->currentRecord][$this->currentField] .= $this->xmlDecode($data);
+                    }
+                }
+                break;
+            default:
+                break;
+        }
+    }
+
+    function elementEndVerbose($parser, $name) {
+        switch(strtolower($name)) {
+            case 'data':
+                if (!$this->isInRelatedSet) ++$this->currentFieldIndex;
+                $this->currentFlag = "";
+                break;
+            case 'field':
+                break;
+            case 'record':
+                if ($this->isInRelatedSet && !$this->FX->usePortalIDs) ++$this->currentSubrecordIndex;
+                if (strlen(trim($this->FX->customPrimaryKey)) > 0) {
+                    if ($this->FX->useInnerArray) {
+                        $this->FX->currentData[$this->FX->currentData[$this->currentRecord][$this->FX->customPrimaryKey][0]]
+                            = $this->FX->currentData[$this->currentRecord];
+                    } else {
+                        if ($this->isRemainName($this->currentField)) {
+                            if ($this->FX->portalAsRecord) {
+                                //
+                            } else {
+                                $this->FX->currentData[$this->FX->currentData[$this->currentRecord][$this->FX->customPrimaryKey][0]]
+                                    = $this->FX->currentData[$this->currentRecord];
+                            }
+                        } else {
+                            $this->FX->currentData[$this->FX->currentData[$this->currentRecord][$this->FX->customPrimaryKey]]
+                                = $this->FX->currentData[$this->currentRecord];
+                        }
+                    }
+                    unset($this->FX->currentData[$this->currentRecord]);
+                }
+                elseif (!$this->isInRelatedSet) {
+                    // add any missing fields as blank data
+                    foreach ($this->FX->fieldInfo as $tempField) {
+                        if (!isset($this->FX->currentData[$this->currentRecord][$tempField['name']])) {
+                            if ($this->FX->useInnerArray) {
+                                $this->FX->currentData[$this->currentRecord][$tempField['name']] = array();
+                            }
+                            else {
+                                $this->FX->currentData[$this->currentRecord][$tempField['name']] = '';
+                            }
+                        }
+                    }
+                }
+                break;
+            case 'relatedset':
+                $this->isInRelatedSet = false;
+                break;
+            default:
+                break;
+        }
+    }
+    /*
+     * The functions for new XML parsing end here
+     */
+
+    function xmlDecode ($value) {
+        if ($this->FX->dataParamsEncoding  != '' && defined('MB_OVERLOAD_STRING')) {
+            return mb_convert_encoding($value, $this->FX->charSet, 'UTF-8');
+        }
+        return preg_replace($this->UTF8SpecialChars, $this->UTF8HTMLEntities, $value);
+    }
+
+    
+}


### PR DESCRIPTION
...r Server 12

Chris Hansen wrote this, and I made some small changes
Note the new usePortalIDs variable on the FX class (not on the RetrieveFM7VerboseData class)
Also, the "fmalt"  FMView command uses RetrieveFM7Data, because it isn't compatible.  is there anything else that isn't compatible?
