### PR TITLE
Fix compatibility with FileMaker Server 12 (deprecated "-recid.op=eq")

### DIFF
--- a/datasource_classes/RetrieveFM7Data.class.php
+++ b/datasource_classes/RetrieveFM7Data.class.php
@@ -52,7 +52,11 @@ class RetrieveFM7Data extends RetrieveFMXML {
                     $op = $this->FX->defaultOperator;
                 }
                 $tempFieldName = str_replace('%3A%3A', '::', urlencode($name));
-                $currentSearch .= '&' . $tempFieldName . '.op=' . $op . '&' . $tempFieldName . '=' . urlencode($value);
+                if ($tempFieldName == '-recid') {
+                    $currentSearch .= '&' . $tempFieldName . '=' . urlencode($value);
+                } else {
+                    $currentSearch .= '&' . $tempFieldName . '.op=' . $op . '&' . $tempFieldName . '=' . urlencode($value);
+                }
             }
         }
         return $currentSearch;


### PR DESCRIPTION
Fix compatibility with FileMaker Server 12 (returns an error with version 12 if the XML query string contains "-recid.op=eq")
