### PR TITLE
Suppress warnings ("A non-numeric value encountered") with PHP 7.1

### DIFF
--- a/FX.php
+++ b/FX.php
@@ -372,8 +372,8 @@ class FX {
 
     function AssembleDataSet ($returnData) {
         $dataSet = array();
-        $FMNext = $this->currentSkip + $this->groupSize;
-        $FMPrevious = $this->currentSkip - $this->groupSize;
+        $FMNext = $this->currentSkip + intval($this->groupSize);
+        $FMPrevious = $this->currentSkip - intval($this->groupSize);
 
         switch ($returnData) {
             case 'object':


### PR DESCRIPTION
Modified FX.php to suppress warnings ("A non-numeric value encountered") with PHP 7.1.

Related page: https://secure.php.net/manual/en/migration71.other-changes.php
(Notices and warnings on arithmetic with invalid strings)